### PR TITLE
Set fallback locale for translation file requests

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -77,9 +77,9 @@ const App: React.FC<AppProps> = ({ Component, pageProps }) => {
   }, []);
 
   React.useEffect(() => {
-    getIntlMessages({ locale: pageProps.locale }).then((intlMessages) =>
-      setIntlMessages(intlMessages)
-    );
+    getIntlMessages({
+      locale: pageProps.locale ?? "en-US",
+    }).then((intlMessages) => setIntlMessages(intlMessages));
   }, [pageProps.locale]);
 
   return (


### PR DESCRIPTION
When the end-user reached to 404 route, there's potentially `hl` search param is not set. To fill this case, set `"en-US"` as a fallback locale.