### PR TITLE
Set cache headers by config

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,5 +1,73 @@
+const MAX_AGE = 60 * 60;
+const STALE_WHILE_REVALIDATE = 60 * 60 * 24;
+
 module.exports = (phase) => {
   return {
+    reactStrictMode: true,
+    serverRuntimeConfig: {
+      rootPath: __dirname,
+    },
+    publicRuntimeConfig: {},
+
+    rewrites: async () => [
+      {
+        source: "/index.json",
+        destination: "/api/index.json",
+      },
+      {
+        source: "/posts/feed.xml",
+        destination: "/api/posts/feed.xml",
+      },
+      {
+        source: "/posts/:slug.json",
+        destination: "/api/posts/[slug].json?slug=:slug",
+      },
+    ],
+    headers: async () => [
+      {
+        source: "/",
+        headers: [
+          {
+            key: "cache-control",
+            value: `max-age=${MAX_AGE}, stale-while-revalidate=${STALE_WHILE_REVALIDATE}, public`,
+          },
+        ],
+      },
+      {
+        source: "/index.json",
+        headers: [
+          {
+            key: "cache-control",
+            value: `max-age=${MAX_AGE}, stale-while-revalidate=${STALE_WHILE_REVALIDATE}, public`,
+          },
+        ],
+      },
+      {
+        source: "/posts/:slug",
+        headers: [
+          {
+            key: "cache-control",
+            value: `max-age=${MAX_AGE}, stale-while-revalidate=${STALE_WHILE_REVALIDATE}, public`,
+          },
+        ],
+      },
+      {
+        source: "/posts/:slug.json",
+        headers: [
+          {
+            key: "cache-control",
+            value: `max-age=${MAX_AGE}, stale-while-revalidate=${STALE_WHILE_REVALIDATE}, public`,
+          },
+        ],
+      },
+    ],
+    images: {
+      domains: [
+        "images.ctfassets.net",
+        "octodex.github.com",
+        "media.graphcms.com",
+      ],
+    },
     webpack: (config, { buildId, dev, isServer, defaultLoaders, webpack }) => {
       traverse(config.module.rules);
 
@@ -34,40 +102,6 @@ module.exports = (phase) => {
       });
 
       return config;
-    },
-    serverRuntimeConfig: {
-      rootPath: __dirname,
-    },
-    publicRuntimeConfig: {},
-    reactStrictMode: true,
-    rewrites: async () => [
-      {
-        source: "/index.md",
-        destination: "/api/index.md",
-      },
-      {
-        source: "/index.json",
-        destination: "/api/index.json",
-      },
-      {
-        source: "/posts/feed.xml",
-        destination: "/api/posts/feed.xml",
-      },
-      {
-        source: "/posts/:slug.md",
-        destination: "/api/posts/[slug].md?slug=:slug",
-      },
-      {
-        source: "/posts/:slug.json",
-        destination: "/api/posts/[slug].json?slug=:slug",
-      },
-    ],
-    images: {
-      domains: [
-        "images.ctfassets.net",
-        "octodex.github.com",
-        "media.graphcms.com",
-      ],
     },
   };
 };

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -274,7 +274,6 @@ const Page: React.VFC<PageProps> = (props) => {
 
 export async function getServerSideProps({
   req,
-  res,
   query,
 }: GetServerSidePropsContext) {
   const locale = getLocaleFromQuery(query);
@@ -287,11 +286,6 @@ export async function getServerSideProps({
   const intlMessages = await getIntlMessages({ locale });
   const posts = await getPostEntryListJson({ locale });
   const indexPage = await getIndexPageJson({ locale });
-
-  res.setHeader(
-    "cache-control",
-    "max-age=60, stale-while-revalidate=3600, public"
-  );
 
   return {
     props: { origin, locale, intlMessages, indexPage, posts },

--- a/pages/posts/[slug].tsx
+++ b/pages/posts/[slug].tsx
@@ -381,7 +381,6 @@ const Page: React.VFC<PageProps> = (props) => {
 
 export async function getServerSideProps({
   req,
-  res,
   query,
   params,
 }: GetServerSidePropsContext) {
@@ -398,11 +397,6 @@ export async function getServerSideProps({
   const intlMessages = await getIntlMessages({ locale });
   const posts = await getPostEntryListJson({ locale });
   const post = await getPostJson({ slug, locale });
-
-  res.setHeader(
-    "cache-control",
-    "max-age=60, stale-while-revalidate=3600, public"
-  );
 
   if (post === null) {
     return {


### PR DESCRIPTION
As the next step of #227, set cache headers in `next.config.js` instead of using `res.setHeader()`. This enables cache setting over static routes as well